### PR TITLE
Support for dimo.telemetry.get_vin one liner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dimo-python-sdk"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   { name="Barrett Kowalsky", email="barrettkowalsky@gmail.com" },
 ]


### PR DESCRIPTION
Minor update to 1.1.0 -> 1.1.1:

- Adds support for a quick way to get vehicle VIN. First creates a VIN VC via Attestation, then queries telemetry `vinVCLatest`