### PR TITLE
refactor: add support for caller provided Session.

### DIFF
--- a/dimo/request.py
+++ b/dimo/request.py
@@ -4,11 +4,10 @@ import requests
 
 class Request:
 
-    session = requests.Session()
-
-    def __init__(self, http_method, url):
+    def __init__(self, http_method, url, session: str):
         self.http_method = http_method
         self.url = url
+        self.session = session
 
     def __call__(self, headers=None, data=None, params=None, **kwargs):
         headers = headers or {}

--- a/dimo/request.py
+++ b/dimo/request.py
@@ -1,10 +1,10 @@
 import json
-import requests
+from requests import Session
 
 
 class Request:
 
-    def __init__(self, http_method, url, session: str):
+    def __init__(self, http_method: str, url: str, session: Session):
         self.http_method = http_method
         self.url = url
         self.session = session


### PR DESCRIPTION
The current implementation just uses the default `requests.Session()`.

This adds the ability to provide your own session for use with requests.