### PR TITLE
refactor: moved HTTPError into errors.py

### DIFF
--- a/dimo/dimo.py
+++ b/dimo/dimo.py
@@ -1,4 +1,3 @@
-from typing_extensions import Optional
 from requests import Session
 
 from .api.attestation import Attestation
@@ -21,7 +20,9 @@ from urllib.parse import urljoin
 
 class DIMO:
 
-    def __init__(self, env: str = "Production", session: Optional[Session] = None) -> None:
+    def __init__(
+        self, env: str = "Production", session: Optional[Session] = None
+    ) -> None:
 
         self.env = env
         # Assert valid environment specified
@@ -32,7 +33,9 @@ class DIMO:
 
         self._client_id: Optional[str] = None
         self._services: Dict[str, Any] = {}
-        self.session = session or Session()  # Use the provided session or create a new one
+        self.session = (
+            session or Session()
+        )  # Use the provided session or create a new one
 
     # Creates a full path for endpoints combining DIMO service, specific endpoint, and optional params
     def _get_full_path(self, service: str, path: str, params=None) -> str:

--- a/dimo/errors.py
+++ b/dimo/errors.py
@@ -30,3 +30,12 @@ def check_optional_type(param_name: str, value: Any, expected_type: Union[Type, 
 
 class DimoValueError(DimoError):
     pass
+
+
+class HTTPError(Exception):
+    """Http error wrapper with status code and (optional) response body"""
+
+    def __init__(self, status: int, message: str, body: Any = None):
+        super().__init__(f"HTTP {status}: {message}")
+        self.status = status
+        self.body = body

--- a/dimo/request.py
+++ b/dimo/request.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any
 from requests import Session, RequestException
-from errors import HTTPError
+from .errors import HTTPError
 
 
 class Request:

--- a/dimo/request.py
+++ b/dimo/request.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 from requests import Session, RequestException
 from .errors import HTTPError
 

--- a/dimo/request.py
+++ b/dimo/request.py
@@ -1,15 +1,7 @@
 import json
 from typing import Any
 from requests import Session, RequestException
-
-
-class HTTPError(Exception):
-    """Http error wrapper with status code and (optional) response body"""
-
-    def __init__(self, status: int, message: str, body: Any = None):
-        super().__init__(f"HTTP {status}: {message}")
-        self.status = status
-        self.body = body
+from errors import HTTPError
 
 
 class Request:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3,7 +3,8 @@ import pytest
 from requests import RequestException
 from unittest.mock import Mock
 
-from dimo.errors import Request, HTTPError
+from dimo.errors import HTTPError
+from dimo.request import Request
 
 
 class DummyResponse:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -3,7 +3,7 @@ import pytest
 from requests import RequestException
 from unittest.mock import Mock
 
-from dimo.request import Request, HTTPError
+from dimo.errors import Request, HTTPError
 
 
 class DummyResponse:


### PR DESCRIPTION
Makes more sense to move all custom error classes into `errors.py`