### PR TITLE
fix: corrected content-type header check.

### DIFF
--- a/dimo/request.py
+++ b/dimo/request.py
@@ -51,7 +51,7 @@ class Request:
             raise HTTPError(status=status or -1, message=str(exc), body=body)
 
         content_type = response.headers.get("Content-Type", "")
-        if "application/json" in content_type:
+        if "json" in content_type:
             return response.json()
 
         return response.content


### PR DESCRIPTION
content type can be both `application/json` and
`application/graphql-response-json` for example, so we simply check for the phrase `json` in the content-type header